### PR TITLE
Add GFM syntax extensions

### DIFF
--- a/Sources/cmark/blocks.c
+++ b/Sources/cmark/blocks.c
@@ -21,6 +21,10 @@
 #include "inlines.h"
 #include "houdini.h"
 #include "buffer.h"
+#include "autolink.h"
+#include "strikethrough.h"
+#include "table.h"
+#include "tagfilter.h"
 
 #define CODE_INDENT 4
 #define TAB_STOP 4
@@ -536,6 +540,10 @@ static cmark_node *finalize_document(cmark_parser *parser) {
 cmark_node *cmark_parse_file(FILE *f, int options) {
   unsigned char buffer[4096];
   cmark_parser *parser = cmark_parser_new(options);
+  cmark_parser_attach_syntax_extension(parser, create_autolink_extension());
+  cmark_parser_attach_syntax_extension(parser, create_strikethrough_extension());
+  cmark_parser_attach_syntax_extension(parser, create_table_extension());
+  cmark_parser_attach_syntax_extension(parser, create_tagfilter_extension());
   size_t bytes;
   cmark_node *document;
 


### PR DESCRIPTION
GFM syntax extensions for _autolink_, _strikethrough_, _table_ and _tagfilter_' attached to default parser.